### PR TITLE
[Feature] Add pr uml render component

### DIFF
--- a/.github/hypertrons-components/sql_label/index.lua
+++ b/.github/hypertrons-components/sql_label/index.lua
@@ -15,21 +15,23 @@
 -- Pull label sql
 on('PullRequestEvent', function (e)
   wrap(function()
-    local prNumer = e.number;
-    local files = listPullRequestFiles(e.number)
-    log('Gonna check sql for '..e.number..', find '..#files..' files in PR')
-    if (#files == 0) then
-      return
-    end
-    local sqls = {}
-    for i=1, #files do
-      local filename = files[i].filename
-      local contentsUrl = files[i].contents_url
-      for j=1, #compConfig.sqlFilesRegex do
-        local sqlName = string.match(filename, compConfig.sqlFilesRegex[j])
-        if (sqlName ~= nil) then
-          addLabels(e.number, { compConfig.label })
-          return
+    if (e.action == 'opened' or e.action == 'synchronize') then
+      local prNumer = e.number;
+      local files = listPullRequestFiles(e.number)
+      log('Gonna check sql for '..e.number..', find '..#files..' files in PR')
+      if (#files == 0) then
+        return
+      end
+      local sqls = {}
+      for i=1, #files do
+        local filename = files[i].filename
+        local contentsUrl = files[i].contents_url
+        for j=1, #compConfig.sqlFilesRegex do
+          local sqlName = string.match(filename, compConfig.sqlFilesRegex[j])
+          if (sqlName ~= nil) then
+            addLabels(e.number, { compConfig.label })
+            return
+          end
         end
       end
     end

--- a/.github/hypertrons.json
+++ b/.github/hypertrons.json
@@ -153,5 +153,11 @@
   },
   "sql_label": {
     "version": 1
+  },
+  "auto_update_contribution": {
+    "version": 1
+  },
+  "pr_uml_renderer": {
+    "version": 1
   }
 }


### PR DESCRIPTION
Signed-off-by: Frankzhaopku <syzhao1988@126.com>

Close #34 , I implement the `pr_uml_renderer` component in Hypertrons because I think it could be a very common ability. See https://github.com/X-lab2017/github-analysis-report-2020/pull/33#issuecomment-679890618 for what this component can do.

Others:

- Add `auto_update_contribution` component in config
- For `pull/sql` label, only need to check `created` and `synchronize` actions for `PullRequestEvent`, no need for all kinds of actions.