### PR TITLE
[Refactor] Contribution sort alphabetically if score is equal

### DIFF
--- a/.github/hypertrons-components/auto_update_contribution/index.lua
+++ b/.github/hypertrons-components/auto_update_contribution/index.lua
@@ -112,6 +112,9 @@ sched(compConfig.schedName, compConfig.sched, function ()
           end
         end
         table.sort(roleContribution[roleName], function(a, b)
+          if (a.score == b.score) then
+            return a.login < b.login
+          end
           return a.score > b.score
         end)
       else


### PR DESCRIPTION
Signed-off-by: Frankzhaopku <syzhao1988@126.com>

When generate contribution doc, if `score` is equal then sort by `login` so it should be a stable sort.

Close #58 