### PR TITLE
[Refactor] change base url

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,7 +2,7 @@
 
 This project consists of several independent components, the architecture of the system is as follows:
 
-![architect-img](http://frank-local.opensource-service.com/umlrenderer/github/X-lab2017/github-analysis-report-2020?path=docs/diagrams/architect.uml)
+![architect-img](http://gar2020.opensource-service.cn/umlrenderer/github/X-lab2017/github-analysis-report-2020?path=docs/diagrams/architect.uml)
 
 Developers only collaborate in this project on GitHub platform, the technical details of the backend are hidden from developers. The backend consists of several services includes:
 

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -76,4 +76,4 @@ Component [SQL verified](https://github.com/X-lab2017/github-analysis-report-202
 
 The core workflow of this project is the PR workflow especially with SQL files invovled and the diagram below shows a whole PR workflow:
 
-![pull-flow](http://frank-local.opensource-service.com/umlrenderer/github/X-lab2017/github-analysis-report-2020?path=docs/diagrams/pull-flow.uml)
+![pull-flow](http://gar2020.opensource-service.cn/umlrenderer/github/X-lab2017/github-analysis-report-2020?path=docs/diagrams/pull-flow.uml)

--- a/docs/zh-cn/architecture.md
+++ b/docs/zh-cn/architecture.md
@@ -2,7 +2,7 @@
 
 本项目由多个独立但相关的系统组成，系统的架构图如下：
 
-![architect-img](http://frank-local.opensource-service.com/umlrenderer/github/X-lab2017/github-analysis-report-2020?path=docs/diagrams/architect.uml)
+![architect-img](http://gar2020.opensource-service.cn/umlrenderer/github/X-lab2017/github-analysis-report-2020?path=docs/diagrams/architect.uml)
 
 在该年报项目中，开发者仅在 GitHub 平台上产生项目协作行为，而后端的技术细节对开发者是屏蔽的。后端由多个服务应用协同构成本项目的协作体系，这些系统包含：
 

--- a/docs/zh-cn/workflow.md
+++ b/docs/zh-cn/workflow.md
@@ -74,4 +74,4 @@
 
 该项目核心为 PR 协作流程，尤其是 SQL 类 PR 的协作流程，对于上述组件构建的完整 PR 流程，可参考下图：
 
-![pull-flow](http://frank-local.opensource-service.com/umlrenderer/github/X-lab2017/github-analysis-report-2020?path=docs/diagrams/pull-flow.uml)
+![pull-flow](http://gar2020.opensource-service.cn/umlrenderer/github/X-lab2017/github-analysis-report-2020?path=docs/diagrams/pull-flow.uml)


### PR DESCRIPTION
First the robot is deployed on my own laptop which is not quite easy to maintain. Now the robot is on cloud and only data service runs on my laptop.

The new base URL is `http://gar2020.opensource-service.cn` so need to change all UML render base URL to make sure they works.